### PR TITLE
[None][feat] Parallel prefault and THP knob for KV cache manager v2 host pools

### DIFF
--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_utils.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import array
+import concurrent.futures
 import ctypes
 import errno
 import functools
@@ -394,6 +395,21 @@ _libc.posix_fallocate.restype = ctypes.c_int
 _libc.posix_fallocate.argtypes = [ctypes.c_int, ctypes.c_longlong, ctypes.c_longlong]
 
 MADV_HUGEPAGE: Final[int] = 14
+MADV_NOHUGEPAGE: Final[int] = 15
+MADV_POPULATE_WRITE: Final[int] = 23
+
+# TLLM_KV_CACHE_MANAGER_V2_THP=0 backs host pools with regular 4KB pages
+# (MADV_NOHUGEPAGE). On nodes with fragmented physical memory and THP
+# defrag=madvise, every 2MB THP fault stalls in direct compaction that
+# rarely succeeds, slowing pool population from GB/s to GB/min.
+USE_THP: Final[bool] = os.environ.get("TLLM_KV_CACHE_MANAGER_V2_THP", "1") == "1"
+# TLLM_KV_CACHE_MANAGER_V2_PREFAULT_THREADS=0 disables prefaulting; pages are
+# then faulted in lazily, single-threaded, inside cuMemHostRegister.
+PREFAULT_THREADS: Final[int] = int(
+    os.environ.get(
+        "TLLM_KV_CACHE_MANAGER_V2_PREFAULT_THREADS", str(min(64, (os.cpu_count() or 32) // 2))
+    )
+)
 
 
 def _madvise(ptr: int, size: int, advice: int) -> None:
@@ -508,8 +524,10 @@ class HostMem:
 
         # Opportunistically advise huge pages for the whole range.
         # The kernel will use huge pages for aligned 2MB chunks within this range.
-        _madvise(self._address, self._size, MADV_HUGEPAGE)
+        _madvise(self._address, self._size, MADV_HUGEPAGE if USE_THP else MADV_NOHUGEPAGE)
 
+        if PREFAULT_THREADS > 0:
+            self._parallel_prefault(PREFAULT_THREADS)
         self._register_to_cuda()
 
     def resize(self, new_size: int) -> None:
@@ -534,6 +552,36 @@ class HostMem:
 
     def __del__(self) -> None:
         self.destroy()
+
+    def _parallel_prefault(self, nthreads: int) -> None:
+        """Fault in all pages with parallel threads before cuMemHostRegister,
+        so registration only pins pages (never allocates them).
+
+        Lazy faulting inside cuMemHostRegister is single-threaded and, under
+        memory pressure or THP compaction stalls, can take minutes for
+        multi-hundred-GiB pools. MADV_POPULATE_WRITE populates in bulk; small
+        chunks keep mmap_lock hold times short (one giant madvise per thread
+        serializes every other thread behind it) and let threads
+        load-balance.
+        """
+        chunk = 512 << 20
+
+        def populate(off: int) -> None:
+            ln = min(chunk, self._size - off)
+            if ln <= 0:
+                return
+            ret = _libc.madvise(
+                ctypes.c_void_p(self._address + off),
+                ctypes.c_size_t(ln),
+                ctypes.c_int(MADV_POPULATE_WRITE),
+            )
+            if ret != 0:
+                # MADV_POPULATE_WRITE requires Linux >= 5.14; fall back to
+                # touching every page.
+                ctypes.memset(self._address + off, 0, ln)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=nthreads) as executor:
+            list(executor.map(populate, range(0, self._size, chunk)))
 
     def _register_to_cuda(self) -> None:
         assert self._num_registered_chunks == 0


### PR DESCRIPTION
## Problem

Large `kv_cache_config.host_cache_size` values (250GB+) make engine startup extremely slow — 45+ minutes spent allocating the host pool on long-running nodes, which exceeds deployment startup deadlines (observed on `eric123/gemma-4-31B-it-new`, where scale-up pods at the current 250GB setting repeatedly failed to come up in time).

Root cause, measured (kernel `vmstat` counters, py-spy, per-phase instrumentation): `HostMem` (`kv_cache_manager_v2/_utils.py`) mmaps the pool and lets `cuMemHostRegister` fault pages in **lazily, on one thread**; the `MADV_HUGEPAGE` hint makes every 2MB fault enter synchronous direct compaction, which fails ~100% of the time on fragmented nodes (`/proc/buddyinfo` order-9 = 0 after weeks of uptime) — population drops from GB/s to **GB/min**. While the pool is being pinned, a node-wide driver lock also slows other pods' CUDA startups and `nvidia-smi` on the same machine.

## Change

Two env knobs in `_utils.py`, following the existing `TLLM_KV_CACHE_MANAGER_V2_DEBUG` convention. **Defaults preserve current behavior** except prefaulting is on:

- `TLLM_KV_CACHE_MANAGER_V2_PREFAULT_THREADS` (default `min(64, ncpu/2)`, `0` = lazy faulting as today): populate the pool with parallel, 512MB-chunked `MADV_POPULATE_WRITE` before registration, so `cuMemHostRegister` only pins pages. Small chunks keep `mmap_lock` hold times short; falls back to `memset` on kernels < 5.14.
- `TLLM_KV_CACHE_MANAGER_V2_THP` (default `1` = today's `MADV_HUGEPAGE`; `0` = `MADV_NOHUGEPAGE`): 4KB pages need no contiguity (no compaction stalls) and fall back to the remote NUMA socket for free. Measured page-table cost is identical in practice (THP faults were falling back to 4KB anyway on fragmented nodes); decode unaffected (HBM-resident); host↔GPU offload is bulk DMA.

## Measurements

gemma-4-31B TP2, 2×B200, `host_cache_size=300GB`/rank (2 pools/rank × 2 allocation rounds = 8 pools/boot), same node, back-to-back, both arms `THP=0`:

| | lazy faulting (today) | 64-thread prefault |
|---|---|---|
| 217.3GiB pool | 57-60s clean / **217s** contended | **13-15s every run** (reg 8-12s) |
| 62.1GiB pool | 18s clean / **180-265s** contended | **6-8s every run** (reg ~2s) |
| total boot | 7m44s / 15m51s | 4m57s / 3m53s |

Prefault was 6-15s on every pool in every run, insensitive to co-tenant activity; lazy faulting swung 18→265s on the same pool. Stock (THP + lazy) at 300GB on the same node did not finish within the startup deadline.

The key property is that boot time becomes **independent of node state**: stock degrades as fragmentation, co-tenant activity, and pool size grow (5min → 24min → does not finish), while the patched path held seconds-per-pool across every condition tested.

## Validation of this exact diff (bind-mounted into `v1.3.0rc16-gemma4fix`)

| config | host_cache/rank | total boot | host-cache rounds |
|---|---|---|---|
| stock baseline (`PREFAULT_THREADS=0`) | 150GB | ~5min | 26s / 25s |
| defaults (THP=1 + prefault) | 150GB | ~4min | 14s / 14s |
| `THP=0` + prefault | 150GB | **2m51s** | 17s / 20s |
| `THP=0` + prefault | 300GB | **~4min** | 35s / 38s |
| defaults (THP=1 + prefault) | 300GB | stalls in THP compaction on a low-free-memory node (~6.7GB/min population); took too long to boot, killed | |

(150GB rows ran back-to-back on the same quiet node — on clean nodes all configs boot; the stock baseline is the config that degrades to 24min/never under fragmentation and contention.)

Serving smoke-tested: completion, streaming, gemma4 tool-calls ✅
