### PR TITLE
[None][feat] KV-cache transfer/staging between two TRT-LLM instances

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -4316,6 +4316,7 @@ class PyExecutor:
             req for req in self.active_requests
             if req.py_disaggregated_params and req.py_disaggregated_params.
             schedule_style != DisaggScheduleStyle.GENERATION_FIRST
+            and not getattr(req.py_disaggregated_params, "kv_transfer_only", False)
         ]
         need_check_one = bool(non_gen_first_reqs) and all(
             req.is_disagg_generation_transmission_in_progress
@@ -4523,6 +4524,12 @@ class PyExecutor:
 
                 self._maybe_prepend_logprobs_and_logits(req, beam_width)
 
+                # kv_transfer_only: transfer done + first token adopted; finish now
+                # (no generation forward pass), KV is committed for reuse.
+                if (req.py_disaggregated_params is not None and getattr(
+                        req.py_disaggregated_params, "kv_transfer_only", None)):
+                    req.finish_by(FinishReason.LENGTH, 0)
+
     def _update_sampler_state_for_disagg_gen_request(self, req, beam_width,
                                                      first_gen_tokens) -> bool:
         """Update beam sampler state with context-side first-token data."""
@@ -4672,6 +4679,7 @@ class PyExecutor:
             req for req in self.active_requests
             if req.py_disaggregated_params and req.py_disaggregated_params.
             schedule_style != DisaggScheduleStyle.GENERATION_FIRST
+            and not getattr(req.py_disaggregated_params, "kv_transfer_only", False)
         ]
         block_transfer = bool(non_gen_first_active) and all(
             req.is_disagg_generation_transmission_in_progress
@@ -5259,6 +5267,16 @@ class PyExecutor:
     def _handle_first_token_response(self, scheduled_batch):
         new_responses = []
         for req in scheduled_batch.generation_requests:
+            # A request already finished before its first-token response (only
+            # kv_transfer_only, which finish_by()s at transmission-complete) gets
+            # its single is_final result from the terminal _handle_responses path.
+            # Emitting a first-token response here too would be a SECOND final for
+            # the same client_id -> the proxy pops on the first and KeyErrors on
+            # this one (fatal engine shutdown). Mirror of the is_finished skip
+            # already in _emit_first_token_responses. Stock requests are never
+            # finished at this point, so this is a no-op for them.
+            if req.is_finished:
+                continue
             if req.py_decoding_iter == 1:
                 logger.debug(
                     f'Send first token response for request {req.py_request_id}'

--- a/tensorrt_llm/disaggregated_params.py
+++ b/tensorrt_llm/disaggregated_params.py
@@ -54,6 +54,9 @@ class DisaggregatedParams:
     ctx_dp_rank: Optional[int] = None
     ctx_info_endpoint: Optional[str] = None
     schedule_style: Optional[DisaggScheduleStyle] = None
+    # generation_only: receive the KV transfer + commit it for reuse, then finish
+    # without generating (prewarming, cache migration/replication, pre-positioning).
+    kv_transfer_only: Optional[bool] = None
     ctx_usage: Optional[Dict[str, Any]] = None
 
     # E-P Disaggregated Params

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -156,6 +156,7 @@ class DisaggregatedParams(OpenAIBaseModel):
     schedule_style: Optional[DisaggScheduleStyle] = None
     conversation_id: Optional[str] = None
     ctx_usage: Optional[UsageInfo] = None
+    kv_transfer_only: Optional[bool] = False
     # TODO(TRTLLM-12407): Multimodal E/PD over trtllm-serve needs these protocol fields too:
     # encoder embedding handles, multimodal hashes, and optional mRoPE handles.
     # Add them here and in to_disaggregated_params()/to_llm_disaggregated_params()
@@ -1427,6 +1428,7 @@ def to_llm_disaggregated_params(
         ctx_dp_rank=disaggregated_params.ctx_dp_rank,
         ctx_info_endpoint=disaggregated_params.ctx_info_endpoint,
         schedule_style=disaggregated_params.schedule_style,
+        kv_transfer_only=disaggregated_params.kv_transfer_only,
         ctx_usage=None if ctx_usage is None else ctx_usage.model_dump(),
     )
 

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -306,6 +306,13 @@ class OpenAIServer(_VideoRoutesMixin):
         self.binding_addr = None
         self.host = None
         self.port = None
+        self._kvt_stats = {"fired": 0, "transferred": 0, "failed": 0, "deduped": 0, "skipped_busy": 0}
+        self._kvt_seen = {}
+        self._kvt_inflight = 0
+        self._kvt_max = int(os.environ.get("KV_TRANSFER_MAX_INFLIGHT", "4"))
+        self._kvt_dedup_ttl = float(os.environ.get("KV_TRANSFER_DEDUP_TTL", "300"))
+        _allow = os.environ.get("KV_TRANSFER_SOURCE_ALLOW", "").strip()
+        self._kvt_allow = set(s.strip() for s in _allow.split(",") if s.strip()) if _allow else None
         hf_tokenizer_path = generator._hf_model_dir or self.tokenizer.tokenizer.name_or_path
         trust_remote_code = generator.args.trust_remote_code
         self.last_iteration_stat = {}
@@ -768,6 +775,73 @@ class OpenAIServer(_VideoRoutesMixin):
             return self.generator._check_health()
         return True
 
+    async def kv_transfer(self, request: Request):
+        """Fire-and-forget KV-cache transfer: {model, messages|prompt, source} -> 202.
+        Pulls the prompt's KV from `source` over the disagg transceiver and commits it
+        locally for reuse, WITHOUT generating. General mechanism (prewarming, cache
+        migration/rebalancing, replication, pre-positioning); the caller never sees
+        disaggregated-serving tickets."""
+        import hashlib
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse(status_code=400, content={"error": "bad json"})
+        source = body.get("source")
+        model = body.get("model") or self.model
+        messages = body.get("messages")
+        prompt = body.get("prompt")
+        if not source or (messages is None and prompt is None):
+            return JSONResponse(status_code=400, content={"error": "require source and messages|prompt"})
+        if self._kvt_allow is not None and source not in self._kvt_allow:
+            return JSONResponse(status_code=403, content={"error": f"source not allowed: {source}"})
+        key = json.dumps(messages, sort_keys=True) if messages is not None else str(prompt)
+        h = hashlib.sha1(key.encode()).hexdigest()
+        now = time.monotonic()
+        last = self._kvt_seen.get(h)
+        if last is not None and (now - last) < self._kvt_dedup_ttl:
+            self._kvt_stats["deduped"] += 1
+            return JSONResponse(status_code=202, content={"status": "deduped", "request_hash": h})
+        if self._kvt_inflight >= self._kvt_max:
+            self._kvt_stats["skipped_busy"] += 1
+            return JSONResponse(status_code=202, content={"status": "skipped_busy", "request_hash": h})
+        self._kvt_seen[h] = now
+        if len(self._kvt_seen) > 20000:
+            self._kvt_seen = {k: v for k, v in self._kvt_seen.items() if now - v < self._kvt_dedup_ttl}
+        self._kvt_inflight += 1
+        self._kvt_stats["fired"] += 1
+        asyncio.create_task(self._do_kv_transfer(model, messages, prompt, source, h))
+        return JSONResponse(status_code=202, content={"status": "accepted", "request_hash": h, "deduped": False})
+
+    async def _do_kv_transfer(self, model, messages, prompt, source, h):
+        import aiohttp
+        is_chat = messages is not None
+        path = "/v1/chat/completions" if is_chat else "/v1/completions"
+        ctx_body = {"model": model, "max_tokens": 1, "temperature": 0, "stream": False,
+                    "disaggregated_params": {"request_type": "context_only"}}
+        ctx_body["messages" if is_chat else "prompt"] = messages if is_chat else prompt
+        try:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=self._kvt_dedup_ttl)) as session:
+                async with session.post(source.rstrip("/") + path, json=ctx_body) as r:
+                    ctx = await r.json()
+                dp = ctx.get("disaggregated_params") or (ctx.get("choices", [{}])[0].get("disaggregated_params"))
+                if not dp:
+                    self._kvt_stats["failed"] += 1
+                    return
+                gen_body = dict(ctx_body)
+                gen_body["disaggregated_params"] = dict(dp, request_type="generation_only", kv_transfer_only=True)
+                async with session.post(f"http://127.0.0.1:{self.port}{path}", json=gen_body) as r2:
+                    await r2.read()
+            self._kvt_stats["transferred"] += 1
+        except Exception as e:
+            self._kvt_stats["failed"] += 1
+            logger.warning(f"[kv-transfer] {h[:8]} failed: {repr(e)[:120]}")
+        finally:
+            self._kvt_inflight -= 1
+
+    async def kv_transfer_stats(self, request: Request):
+        return JSONResponse(content={**self._kvt_stats, "inflight": self._kvt_inflight,
+                                     "seen": len(self._kvt_seen), "max_inflight": self._kvt_max})
+
     def register_routes(self):
         self.app.add_api_route("/health", self.health, methods=["GET"])
         self.app.add_api_route("/health_generate",
@@ -830,6 +904,8 @@ class OpenAIServer(_VideoRoutesMixin):
             "/v1/chat/completions",
             self.openai_chat if not self.use_harmony else self.chat_harmony,
             methods=["POST"])
+        self.app.add_api_route("/v1/kv_transfer", self.kv_transfer, methods=["POST"])
+        self.app.add_api_route("/v1/kv_transfer/stats", self.kv_transfer_stats, methods=["GET"])
         self.app.add_api_route("/v1/responses",
                                self.openai_responses,
                                methods=["POST"])


### PR DESCRIPTION
## What

Builds on the disagg transceiver to add a general, **cross-instance** KV-transfer mechanism. A
`generation_only` request with **`kv_transfer_only`** pulls the prompt's KV from a **source
instance** over the transceiver, commits it to the local reuse cache, and **finishes without a
generation forward pass**. The two instances just need the cache transceiver enabled — they are not
limited to a dedicated context/generation disagg pair, and need not be co-located (UCX does cross-node
over IB too). One mechanism, many uses — KV prewarming, cache migration/rebalancing between instances,
replication, pre-positioning ahead of a routing decision.

Plus a fire-and-forget HTTP wrapper, so a caller can warm/move a prompt's KV with one call and no
knowledge of disaggregated serving:

**`POST /v1/kv_transfer`** — accepts the request, kicks off the transfer in the background, and
returns `202` immediately (does not wait for the transfer to finish).
- Request body:
  - `source` (required) — base URL of the instance to pull the prompt's KV from.
  - `messages` **or** `prompt` (one required) — the prompt, in chat or completions form.
  - `model` (optional) — defaults to the server's served model.
- Response: `202` with `{status, request_hash}`, where `status` is one of `accepted`, `deduped`, or
  `skipped_busy`. Errors: `400` (missing `source` or prompt), `403` (`source` not in the allowlist).
- Guards: de-duplicates identical prompts seen within a TTL; caps concurrent transfers and sheds the
  excess as `skipped_busy`; optional `source` allowlist.

**`GET /v1/kv_transfer/stats`** — observability counters: `fired`, `transferred`, `failed`,
`deduped`, `skipped_busy`, plus live `inflight`, `seen` (dedup-table size), and `max_inflight`.

It composes the existing disaggregated-serving interface rather than adding new transport: the
`context_only` leg makes `source` prefill the prompt and return its disagg ticket (the opaque
transceiver handle for that prompt's KV), and replaying that ticket back to this instance as a
`generation_only` request (with `kv_transfer_only`) makes the engine pull the KV over the transceiver
and commit it for reuse — driven over loopback HTTP so it goes through the normal serving path.

## Changes (all additive — `+99/-0`, 4 files; regular disagg byte-identical)

- **`disaggregated_params.py` / `serve/openai_protocol.py`** — `kv_transfer_only` field + passthrough.
- **`_torch/pyexecutor/py_executor.py`**
  - `_prepare_disagg_gen_transmission_complete`: when `kv_transfer_only`, finish via
    `finish_by(LENGTH, 0)` **after** normal sampler setup → no forward pass, KV committed for reuse.
    (Going through normal setup matters — skipping it corrupts the batched sampler under concurrency.)
  - `_handle_first_token_response`: **skip already-finished requests**. A `kv_transfer_only` req is
    finished at transmission-complete, so without this it would emit a first-token response *and* the
    terminal response — two `is_final` results for one `client_id` → the proxy pops on the first and
    `KeyError`s on the second → fatal shutdown. The skip mirrors the existing `is_finished` guard in
    `_emit_first_token_responses`, and is a **no-op for stock requests** (never finished at first-token).
  - Exclude `kv_transfer_only` reqs from the `block_transfer` / `need_check_one` wait so they never
    stall live traffic (rc19 still has the always-on transfer block).

## Validation

Validated on rc19 with gpt-oss-120b.
